### PR TITLE
Use share-alt icon on admin instead of resize-small

### DIFF
--- a/app/views/spree/admin/products/_related_products.html.erb
+++ b/app/views/spree/admin/products/_related_products.html.erb
@@ -1,3 +1,3 @@
 <li<%== ' class="active"' if current == "Related Products" %>>
-  <%= link_to_with_icon 'resize-small', Spree.t(:related_products), related_admin_product_url(@product) %>
+  <%= link_to_with_icon 'share-alt', Spree.t(:related_products), related_admin_product_url(@product) %>
 </li>


### PR DESCRIPTION
### Contains
- Use ` share-alt` icon to replace the missing `resize-small` one

### Preview
Before:
![screen shot 2016-05-16 at 10 11 55 pm](https://cloud.githubusercontent.com/assets/957520/15310188/453358c8-1bb3-11e6-8ed6-06c6b31c098f.png)

After:
![screen shot 2016-05-16 at 10 05 50 pm](https://cloud.githubusercontent.com/assets/957520/15310189/49f57f4e-1bb3-11e6-9b1e-1c2fe310734d.png)
