### PR TITLE
some fixes for the new solidus 1.3 backend

### DIFF
--- a/app/views/spree/admin/products/_related_products_table.html.erb
+++ b/app/views/spree/admin/products/_related_products_table.html.erb
@@ -25,12 +25,9 @@
         <td><%= relation.relation_type.name %></td>
         <td>
           <%= form_for relation, url: admin_product_relation_path(relation.relatable, relation) do |f| %>
-            <div class="input-group">
-              <%= f.text_field :discount_amount, class: 'form-control text-center' %>
-              <span class="input-group-btn">
-                <%= f.button Spree.t(:update), type: 'submit', class: 'btn btn-primary' %>
-              </span>
-            </div>
+
+            <%= f.text_field :discount_amount, class: 'form-control text-center' %>
+            <%= f.button Spree.t(:update), type: 'submit', class: 'button btn-primary' %>
           <% end %>
         </td>
         <td class="actions">

--- a/app/views/spree/admin/products/related.html.erb
+++ b/app/views/spree/admin/products/related.html.erb
@@ -7,6 +7,7 @@
     <%= Spree.t(:no_relation_types) %>
   </div>
 <% else %>
+
   <div id="add-line-item">
     <fieldset>
       <legend><%= Spree.t(:add_related_product) %></legend>
@@ -17,23 +18,22 @@
             <%= hidden_field_tag :add_variant_name, '', class: 'variant_autocomplete', style: "display: block !important;" %>
           </div>
         </div>
+
         <div id="related_product_type" class="col-md-4">
           <div class="form-group">
             <%= label_tag :add_type, Spree.t(:type) %>
-            <%= select_tag :add_type, options_for_select(@relation_types.map { |rt| [rt.name, rt.id] }), class: 'select2' %>
+            <%= select_tag :add_type, options_for_select(@relation_types.map { |rt| [rt.name, rt.id] }), class: 'select2', style: "display: block" %>
           </div>
         </div>
+
         <div id="related_product_discount" class="col-md-3">
           <div class="form-group">
             <%= label_tag :add_discount, Spree.t(:discount_amount) %>
-            <div class="input-group">
-              <%= text_field_tag :add_discount, 0.0, class: 'form-control text-center' %>
-              <span class="input-group-btn">
-                <%= button_link_to Spree.t(:add), admin_product_relations_url(@product), icon: 'add', class: 'btn-success', id: 'add_related_product', data: { update: 'products-table-wrapper' } %>
-              </span>
-            </div>
+            <%= text_field_tag :add_discount, 0.0, class: 'form-control text-center' %>
           </div>
         </div>
+
+        <%= button_link_to Spree.t(:add), admin_product_relations_url(@product), icon: 'add', id: 'add_related_product', data: { update: 'products-table-wrapper' } %>
       </div>
     </fieldset>
   </div>

--- a/app/views/spree/admin/products/related.html.erb
+++ b/app/views/spree/admin/products/related.html.erb
@@ -12,29 +12,33 @@
     <fieldset>
       <legend><%= Spree.t(:add_related_product) %></legend>
       <div class="row">
-        <div id="related_product_name" class="col-md-5">
+        <div id="related_product_name" class="">
           <div class="form-group">
             <%= label_tag :add_variant_name, Spree.t(:name_or_sku_short) %>
             <%= hidden_field_tag :add_variant_name, '', class: 'variant_autocomplete', style: "display: block !important;" %>
           </div>
         </div>
 
-        <div id="related_product_type" class="col-md-4">
+        <div id="related_product_type" class="column">
           <div class="form-group">
             <%= label_tag :add_type, Spree.t(:type) %>
             <%= select_tag :add_type, options_for_select(@relation_types.map { |rt| [rt.name, rt.id] }), class: 'select2', style: "display: block" %>
           </div>
         </div>
 
-        <div id="related_product_discount" class="col-md-3">
+        <div id="related_product_discount" class="four width column">
           <div class="form-group">
             <%= label_tag :add_discount, Spree.t(:discount_amount) %>
             <%= text_field_tag :add_discount, 0.0, class: 'form-control text-center' %>
           </div>
         </div>
 
-        <%= button_link_to Spree.t(:add), admin_product_relations_url(@product), icon: 'add', id: 'add_related_product', data: { update: 'products-table-wrapper' } %>
       </div>
+      <div class='row'>
+        <div class='column'>
+          <%= button_link_to Spree.t(:add), admin_product_relations_url(@product), icon: 'add', id: 'add_related_product', data: { update: 'products-table-wrapper' } %>
+        <div>
+      <div>
     </fieldset>
   </div>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -16,3 +16,6 @@ de:
     add_related_product: Verwandtes Produkt hinzufügen
     name_or_sku_short: Name oder Artikelnummer
     no_relation_types: "Sie müssen Verwandschaftstypen konfigurieren, bevor Sie diese Funktion nutzen können."
+    admin:
+      tab:
+        relation_types: Verwandschaftstypen


### PR DESCRIPTION
input-group seems to be broken in new solidus backend and the 'add' button was not displayed properly. So I change the structure a little bit and added german translation for the main navigation