### PR TITLE
Set active the related type tab if selected

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -1,0 +1,6 @@
+Spree::Backend::Config.configure do |config|
+  break if !config.respond_to? :menu_items
+  config.menu_items.detect { |menu_item|
+    menu_item.label == :products
+  }.sections << :relation_types
+end


### PR DESCRIPTION
Set active and keep the sub menu open when the related type tab under
products menu is selected.