### PR TITLE
Update add_product_relation_admin_sub_menu_tab.rb

### DIFF
--- a/app/overrides/add_product_relation_admin_sub_menu_tab.rb
+++ b/app/overrides/add_product_relation_admin_sub_menu_tab.rb
@@ -2,5 +2,6 @@ Deface::Override.new(
   virtual_path: 'spree/admin/shared/_product_sub_menu',
   name: 'add_product_relation_admin_sub_menu_tab',
   insert_bottom: '[data-hook="admin_product_sub_tabs"]',
-  text: '<%= tab :relation_types %>'
+  text: '<%= tab :relation_types %>',
+  original: 'd1a70da8f31da0a082c6c5333d9837dcaca65c65'
 )


### PR DESCRIPTION
I was seeing a Deface error in the logs:

```ruby
Deface: [WARNING] No :original defined for 'add_product_relation_admin_sub_menu_tab', you should change its definition to include:
 :original => 'd1a70da8f31da0a082c6c5333d9837dcaca65c65' 
```

This PR should take care of that.