### PR TITLE
Namespaced product link to admin in _related_products_table.html.erb

### DIFF
--- a/app/views/spree/admin/products/_related_products_table.html.erb
+++ b/app/views/spree/admin/products/_related_products_table.html.erb
@@ -21,11 +21,10 @@
         <td class="handle move-handle">
           <span class="icon icon-move handle"></span>
         </td>
-        <td><%= link_to relation.related_to.name, relation.related_to %></td>
+        <td><%= link_to relation.related_to.name, admin_product_path(relation.related_to) %></td>
         <td><%= relation.relation_type.name %></td>
         <td>
           <%= form_for relation, url: admin_product_relation_path(relation.relatable, relation) do |f| %>
-
             <%= f.text_field :discount_amount, class: 'form-control text-center' %>
             <%= f.button Spree.t(:update), type: 'submit', class: 'button btn-primary' %>
           <% end %>


### PR DESCRIPTION
Previously the link was resolving to products_path which maybe
undefined for users not using solidus frontend.
Replaces pull request #18 