### PR TITLE
Add Deface original hash to override

### DIFF
--- a/app/overrides/add_related_product_admin_tabs.rb
+++ b/app/overrides/add_related_product_admin_tabs.rb
@@ -2,5 +2,6 @@ Deface::Override.new(
   virtual_path: 'spree/admin/shared/_product_tabs',
   name: 'add_related_products_admin_tab',
   insert_bottom: '[data-hook="admin_product_tabs"]',
-  partial: 'spree/admin/products/related_products'
+  partial: 'spree/admin/products/related_products',
+  original: '4baaf4bff6bb1ddf0a8f9592833bd5794a3b1943'
 )


### PR DESCRIPTION
I’ve been seeing Deface warnings in my logs about needing to add the original hash to this override. This PR adds the hash of the current `master` view from Solidus.