### PR TITLE
Rename cache_key interface methods to related_cache_key

### DIFF
--- a/app/decorators/models/product/add_relation_interface_methods.rb
+++ b/app/decorators/models/product/add_relation_interface_methods.rb
@@ -5,7 +5,7 @@ module SolidusRelatedProducts
         name
       end
 
-      def cache_key
+      def related_cache_key
         updated_at
       end
 

--- a/app/decorators/models/variant/add_relation_interface_methods.rb
+++ b/app/decorators/models/variant/add_relation_interface_methods.rb
@@ -5,7 +5,7 @@ module SolidusRelatedProducts
         descriptive_name
       end
 
-      def cache_key
+      def related_cache_key
         product.updated_at
       end
 

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe Spree::Product, type: :model do
       @relation_type = create(:product_relation_type, name: 'Related Products')
     end
 
-    describe '.cache_key' do
+    describe '.related_cache_key' do
       it 'returns updated_at attribute' do
-        expect(@product.cache_key).to eq(@product.updated_at)
+        expect(@product.related_cache_key).to eq(@product.updated_at)
       end
     end
 

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Spree::Variant, type: :model do
   let(:variant) { create(:variant) }
 
-  describe '.cache_key' do
+  describe '.related_cache_key' do
     it 'returns product updated_at attribute' do
-      expect(variant.cache_key).to eq(variant.product.updated_at)
+      expect(variant.related_cache_key).to eq(variant.product.updated_at)
     end
   end
 


### PR DESCRIPTION
Avoid the solidus cache_key method override.