### PR TITLE
Use after_discard instead of after_destroy when available

### DIFF
--- a/app/decorators/models/product/add_relation_methods.rb
+++ b/app/decorators/models/product/add_relation_methods.rb
@@ -8,6 +8,7 @@ module SolidusRelatedProducts
 
         # When a Spree::Product is destroyed, we also want to destroy all Spree::Relations
         # "from" it as well as "to" it.
+        base.after_discard :destroy_product_relations if base.respond_to?(:after_discard)
         base.after_destroy :destroy_product_relations
       end
 

--- a/spec/decorators/models/product/add_relation_methods_spec.rb
+++ b/spec/decorators/models/product/add_relation_methods_spec.rb
@@ -1,0 +1,27 @@
+module SolidusRelatedProducts
+  module Product
+    RSpec.describe AddRelationMethods do
+      describe '#destroy_product_relations' do
+        let(:klass) { Class.new(ActiveRecord::Base) }
+
+        it 'adds relation removal hook with after_destroy' do
+          expect(klass).to receive(:after_destroy).with(:destroy_product_relations)
+          klass.prepend(AddRelationMethods)
+        end
+
+        context 'when after_discard is available' do
+          let(:klass) do
+            Class.new(ActiveRecord::Base) do
+              def self.after_discard(*args); end
+            end
+          end
+
+          it 'adds relation removal hook with after_discard' do
+            expect(klass).to receive(:after_discard).with(:destroy_product_relations)
+            klass.prepend(AddRelationMethods)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As described in #36 the `after_destroy` hook is no longer called, causing orphaned records on the destruction of a product