### PR TITLE
standardize backend button style for New Relation

### DIFF
--- a/app/views/spree/admin/relation_types/index.html.erb
+++ b/app/views/spree/admin/relation_types/index.html.erb
@@ -3,7 +3,9 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_relation_type), new_object_url, class: 'btn-primary', id: 'admin_new_relation_type' %>
+  <li>
+    <%= link_to t('spree.new_relation_type'), new_object_url, id: 'admin_new_relation_type', class: 'btn btn-primary' %>
+  </li>
 <% end %>
 
 <% if @relation_types.any? %>


### PR DESCRIPTION
This PR standardizes the styling of the backend button for the New Relation action.

Old:

<img width="265" alt="screen shot 2018-12-05 at 9 33 06 am" src="https://user-images.githubusercontent.com/2460418/49532352-2759f580-f871-11e8-96b0-006b78027f71.png">


New:

<img width="201" alt="screen shot 2018-12-05 at 9 34 41 am" src="https://user-images.githubusercontent.com/2460418/49532361-2a54e600-f871-11e8-9544-4b6852b76bb4.png">
