### PR TITLE
Standardize breadcrumbs for relation_types/edit

### DIFF
--- a/app/views/spree/admin/relation_types/edit.html.erb
+++ b/app/views/spree/admin/relation_types/edit.html.erb
@@ -1,10 +1,7 @@
-<% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::RelationType.model_name.human) %>
-<% end %>
+<% admin_layout "full-width" %>
 
-<% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::RelationType.model_name.human), spree.admin_relation_types_path, class: 'btn-primary' %>
-<% end %>
+<% admin_breadcrumb(link_to plural_resource_name(Spree::RelationType), spree.admin_relation_types_path) %>
+<% admin_breadcrumb(@relation_type.name) %>
 
 <%= form_for [:admin, @relation_type] do |f| %>
   <fieldset>


### PR DESCRIPTION
This standardizes the admin breadcrumbs to be more similar to other Solidus backend views.

Old:

<img width="816" alt="screen shot 2018-12-05 at 9 44 10 am" src="https://user-images.githubusercontent.com/2460418/49533233-56716680-f873-11e8-84e8-3eedad1abc6f.png">

New:

<img width="880" alt="screen shot 2018-12-05 at 9 51 54 am" src="https://user-images.githubusercontent.com/2460418/49533273-6ab56380-f873-11e8-9595-49beab259db7.png">
