### PR TITLE
Replace button_link_to helper with link_to helper

### DIFF
--- a/app/views/spree/admin/products/related.html.erb
+++ b/app/views/spree/admin/products/related.html.erb
@@ -38,8 +38,8 @@
 
       <div class='row'>
         <div class='column'>
-          <%= button_link_to Spree.t(:add), admin_product_relations_url(@product),
-            id: 'add_related_product', data: { update: 'products-table-wrapper' } %>
+          <%= link_to Spree.t(:add), admin_product_relations_url(@product),
+            id: 'add_related_product', class: 'btn btn-primary', data: { update: 'products-table-wrapper' } %>
         <div>
       <div>
     </fieldset>


### PR DESCRIPTION
`button_link_to` helper is deprecated in Solidus (refs: https://github.com/solidusio/solidus/pull/2601).
So I replaced `button_link_to` with `link_to` helper.