### PR TITLE
Relax Rails version dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "solidus", github: "solidusio/solidus", branch: branch
 
 if branch == 'master' || branch >= "v2.0"
   gem "rails-controller-testing", group: :test
-  gem "rails", "<= 5.2.1"
 else
   gem "rails_test_params_backport", group: :test
   gem "rails", "~> 4.2.7"


### PR DESCRIPTION
We don't need anymore to lock this extension to Rails 5.2.1 since solidus core is now compatible with it.

ref solidusio/solidus#2992