### PR TITLE
remove deprecated has_rdoc

### DIFF
--- a/solidus_related_products.gemspec
+++ b/solidus_related_products.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.has_rdoc = false
-
   s.add_runtime_dependency 'solidus_backend', ['>= 1.0', '< 3']
   s.add_runtime_dependency 'solidus_support'
   s.add_runtime_dependency 'deface', '~> 1.0'


### PR DESCRIPTION
This fixes deprecation warnings as below:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
```