### PR TITLE
Fix Travis build

### DIFF
--- a/solidus_related_products.gemspec
+++ b/solidus_related_products.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails', '~> 3.4'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'capybara', '~> 2.5'
   s.add_development_dependency 'capybara-screenshot', '~> 1.0'
   s.add_development_dependency 'poltergeist', '~> 1.9'

--- a/spec/factories/relation_factory.rb
+++ b/spec/factories/relation_factory.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :product_relation, class: Spree::Relation do
     association :relatable, factory: :product
     association :related_to, factory: :product
-    relation_type 'Spree::Product'
+    relation_type { 'Spree::Product' }
   end
 
   factory :variant_relation, class: Spree::Relation do
     association :relatable, factory: :product
     association :related_to, factory: :variant
-    relation_type 'Spree::Variant'
+    relation_type { 'Spree::Variant' }
   end
 end

--- a/spec/factories/relation_type_factory.rb
+++ b/spec/factories/relation_type_factory.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :product_relation_type, class: Spree::RelationType do
     name       { ('A'..'Z').to_a.sample(6).join }
-    applies_to 'Spree::Product'
+    applies_to { 'Spree::Product' }
   end
 
   factory :variant_relation_type, class: Spree::RelationType do
     name       { ('A'..'Z').to_a.sample(6).join }
-    applies_to 'Spree::Variant'
+    applies_to { 'Spree::Variant' }
   end
 end


### PR DESCRIPTION
This PR introduces the following changes to get a green Travis build once again:

* Lock SQLite3 to version 1.3 (see commit's description for details)
* Use dynamic attributes on factories