### PR TITLE
Add 'description' in `Related Products` & `Related Variants` views

### DIFF
--- a/app/assets/javascripts/spree/backend/create_relation.js.coffee
+++ b/app/assets/javascripts/spree/backend/create_relation.js.coffee
@@ -3,6 +3,7 @@ class CreateRelation
     @relatedToInputSelector = '#add_related_to_name'
     @relationTypeInputSelector = '#add_type'
     @discountInputSelector = '#add_discount'
+    @descriptionInputSelector = '#add_description'
 
     @setupListeners()
 
@@ -21,7 +22,8 @@ class CreateRelation
         data: {
           'relation[related_to_id]': $(@relatedToInputSelector).val(),
           'relation[relation_type_id]': $(@relationTypeInputSelector).val(),
-          'relation[discount_amount]' : $(@discountInputSelector).val()
+          'relation[discount_amount]' : $(@discountInputSelector).val(),
+          'relation[description]' : $(@descriptionInputSelector).val()
         }
       })
 

--- a/app/controllers/spree/admin/relations_controller.rb
+++ b/app/controllers/spree/admin/relations_controller.rb
@@ -19,9 +19,10 @@ module Spree
 
       def update
         @relation = Relation.find(params[:id])
-        @relation.update_attribute :discount_amount, relation_params[:discount_amount] || 0
-
-        redirect_to(related_admin_product_url(@relation.relatable))
+        if @relation.update_attributes(relation_params)
+          flash[:success] = flash_message_for(@relation, :successfully_updated)
+          redirect_to(related_admin_product_url(@relation.relatable))
+        end
       end
 
       def update_positions
@@ -65,6 +66,7 @@ module Spree
           :relatable,
           :related_to_id,
           :discount_amount,
+          :description,
           :relation_type_id,
           :position
         ]

--- a/app/controllers/spree/admin/variants/relations_controller.rb
+++ b/app/controllers/spree/admin/variants/relations_controller.rb
@@ -20,9 +20,10 @@ module Spree
 
         def update
           @relation = Relation.find(params[:id])
-          @relation.update_attribute :discount_amount, relation_params[:discount_amount] || 0
-
-          redirect_to(edit_admin_product_variant_path(@relation.relatable.product, @relation.relatable))
+          if @relation.update_attributes(relation_params)
+            flash[:success] = flash_message_for(@relation, :successfully_updated)
+            redirect_to(edit_admin_product_variant_path(@relation.relatable.product, @relation.relatable))
+          end
         end
 
         def update_positions
@@ -66,6 +67,7 @@ module Spree
             :relatable,
             :related_to_id,
             :discount_amount,
+            :description,
             :relation_type_id,
             :position
           ]

--- a/app/controllers/spree/api/relations_controller.rb
+++ b/app/controllers/spree/api/relations_controller.rb
@@ -59,6 +59,7 @@ module Spree
           :relatable,
           :related_to_id,
           :discount_amount,
+          :description,
           :relation_type_id,
           :related_to_type,
           :position

--- a/app/controllers/spree/api/variants/relations_controller.rb
+++ b/app/controllers/spree/api/variants/relations_controller.rb
@@ -60,6 +60,7 @@ module Spree
             :relatable,
             :related_to_id,
             :discount_amount,
+            :description,
             :relation_type_id,
             :related_to_type,
             :position

--- a/app/views/spree/admin/products/_related_products_table.html.erb
+++ b/app/views/spree/admin/products/_related_products_table.html.erb
@@ -11,6 +11,7 @@
       <th></th>
       <th><%= I18n.t('spree.name') %></th>
       <th><%= I18n.t('spree.type') %></th>
+      <th><%= I18n.t('spree.description') %></th>
       <th><%= I18n.t('spree.discount_amount') %></th>
       <th class="actions"></th>
     </tr>
@@ -25,8 +26,14 @@
         <td><%= relation.relation_type.name %></td>
         <td>
           <%= form_for relation, url: admin_product_relation_path(relation.relatable, relation) do |f| %>
+            <%= f.text_field :description, class: 'form-control text-center' %>
+            <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary', id: 'update_description' %>
+          <% end %>
+        </td>
+        <td>
+          <%= form_for relation, url: admin_product_relation_path(relation.relatable, relation) do |f| %>
             <%= f.text_field :discount_amount, class: 'form-control text-center' %>
-            <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary' %>
+            <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary', id: 'update_discount_amount'  %>
           <% end %>
         </td>
         <td class="actions">

--- a/app/views/spree/admin/products/related.html.erb
+++ b/app/views/spree/admin/products/related.html.erb
@@ -12,7 +12,7 @@
     <fieldset>
       <legend><%= I18n.t('spree.add_related_product') %></legend>
       <div data-hook="admin_product_related_products_add" class="row">
-        <div id="related_product_type" class="col-4">
+        <div id="related_product_type" class="col-3">
           <div class="form-group">
             <%= label_tag :add_type, I18n.t('spree.type') %>
             <%= select_tag :add_type, options_for_select(
@@ -21,14 +21,21 @@
           </div>
         </div>
 
-        <div id="related_product_name" class="col-4">
+        <div id="related_product_name" class="col-3">
           <div class="form-group">
             <%= label_tag :add_related_to_name, I18n.t('spree.name_or_sku_short') %>
             <%= hidden_field_tag :add_related_to_name, '', class: 'related_to_autocomplete' %>
           </div>
         </div>
 
-        <div id="related_product_discount" class="col-4">
+        <div id="related_product_description" class="col-3">
+          <div class="form-group">
+            <%= label_tag :add_description, I18n.t('spree.description') %>
+            <%= text_field_tag :add_description, '', class: 'form-control text-center' %>
+          </div>
+        </div>
+
+        <div id="related_product_discount" class="col-3">
           <div class="form-group">
             <%= label_tag :add_discount, I18n.t('spree.discount_amount') %>
             <%= text_field_tag :add_discount, 0.0, class: 'form-control text-center' %>

--- a/app/views/spree/admin/variants/_related.html.erb
+++ b/app/views/spree/admin/variants/_related.html.erb
@@ -8,7 +8,7 @@
     <fieldset>
       <legend><%= I18n.t('spree.add_related_product') %></legend>
       <div data-hook="admin_product_related_products_add" class="row">
-        <div id="related_product_type" class="col-4">
+        <div id="related_product_type" class="col-3">
           <div class="form-group">
             <%= label_tag :add_type, I18n.t('spree.type') %>
             <%= select_tag :add_type, options_for_select(
@@ -17,14 +17,21 @@
           </div>
         </div>
 
-        <div id="related_product_name" class="col-4">
+        <div id="related_product_name" class="col-3">
           <div class="form-group">
             <%= label_tag :add_related_to_name, I18n.t('spree.name_or_sku_short') %>
             <%= hidden_field_tag :add_related_to_name, '', class: 'related_to_autocomplete' %>
           </div>
         </div>
 
-        <div id="related_product_discount" class="col-4">
+        <div id="related_product_description" class="col-3">
+          <div class="form-group">
+            <%= label_tag :add_description, I18n.t('spree.description') %>
+            <%= text_field_tag :add_description, '', class: 'form-control text-center' %>
+          </div>
+        </div>
+
+        <div id="related_product_discount" class="col-3">
           <div class="form-group">
             <%= label_tag :add_discount, I18n.t('spree.discount_amount') %>
             <%= text_field_tag :add_discount, 0.0, class: 'form-control text-center' %>

--- a/app/views/spree/admin/variants/_related_products_table.html.erb
+++ b/app/views/spree/admin/variants/_related_products_table.html.erb
@@ -11,6 +11,7 @@
       <th></th>
       <th><%= I18n.t('spree.name') %></th>
       <th><%= I18n.t('spree.type') %></th>
+      <th><%= I18n.t('spree.description') %></th>
       <th><%= I18n.t('spree.discount_amount') %></th>
       <th class="actions"></th>
     </tr>
@@ -25,8 +26,14 @@
         <td><%= relation.relation_type.name %></td>
         <td>
           <%= form_for relation, url: admin_product_variant_relation_path(relation.relatable.product, relation.relatable, relation) do |f| %>
+            <%= f.text_field :description, class: 'form-control text-center' %>
+            <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary', id: 'update_description' %>
+          <% end %>
+        </td>
+        <td>
+          <%= form_for relation, url: admin_product_variant_relation_path(relation.relatable.product, relation.relatable, relation) do |f| %>
             <%= f.text_field :discount_amount, class: 'form-control text-center' %>
-            <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary' %>
+            <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary', id: 'update_discount_amount'  %>
           <% end %>
         </td>
         <td class="actions">

--- a/db/migrate/20190513101010_add_description_to_spree_relations.rb
+++ b/db/migrate/20190513101010_add_description_to_spree_relations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDescriptionToSpreeRelations < SolidusSupport::Migration[4.2]
+  def change
+    add_column :spree_relations, :description, :string
+  end
+end

--- a/spec/controllers/spree/admin/relations_controller_spec.rb
+++ b/spec/controllers/spree/admin/relations_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Spree::Admin::RelationsController, type: :controller do
 
     context '#update' do
       it 'redirects to product/related url' do
-        put :update, params: { product_id: product.id, id: relation.id, relation: { discount_amount: 2.0 } }
+        put :update, params: { product_id: product.id, id: relation.id, relation: { discount_amount: 2.0, description: 'Related Description' } }
         expect(response).to redirect_to(spree.admin_product_path(relation.relatable) + '/related')
       end
     end

--- a/spec/controllers/spree/admin/variants/relations_controller_spec.rb
+++ b/spec/controllers/spree/admin/variants/relations_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Spree::Admin::Variants::RelationsController, type: :controller do
 
     context '#update' do
       it 'redirects to product/related url' do
-        put :update, params: { product_id: product.id, variant_id: variant.id, id: relation.id, relation: { discount_amount: 2.0 } }
+        put :update, params: { product_id: product.id, variant_id: variant.id, id: relation.id, relation: { discount_amount: 2.0, description: 'Related Description' } }
         expect(response).to redirect_to(spree.edit_admin_product_variant_path(relation.relatable.product, relation.relatable))
       end
     end

--- a/spec/controllers/spree/api/relations_controller_spec.rb
+++ b/spec/controllers/spree/api/relations_controller_spec.rb
@@ -60,11 +60,12 @@ RSpec.describe Spree::Api::RelationsController, type: :controller do
           format: :json,
           product_id: product.id,
           id: relation.id,
-          relation: { discount_amount: 2.0 }
+          relation: { discount_amount: 2.0, description: 'Related Description' }
         }
         expect {
           put :update, params: params
         }.to change { relation.reload.discount_amount.to_s }.from('0.0').to('2.0')
+          .and change { relation.reload.description }.from(nil).to('Related Description')
       end
     end
 

--- a/spec/controllers/spree/api/variants/relations_controller_spec.rb
+++ b/spec/controllers/spree/api/variants/relations_controller_spec.rb
@@ -63,11 +63,12 @@ RSpec.describe Spree::Api::Variants::RelationsController, type: :controller do
           product_id: product.id,
           variant_id: variant.id,
           id: relation.id,
-          relation: { discount_amount: 2.0 }
+          relation: { discount_amount: 2.0, description: 'Related Description' }
         }
         expect {
           put :update, params: params
         }.to change { relation.reload.discount_amount.to_s }.from('0.0').to('2.0')
+          .and change { relation.reload.description }.from(nil).to('Related Description')
       end
     end
 

--- a/spec/features/spree/admin/product_relation_spec.rb
+++ b/spec/features/spree/admin/product_relation_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature 'Admin Product Relation', :js do
     within('#add-line-item') do
       select2_search product_relation_type.name, from: 'Type'
       select2_search other_product.name, from: 'Name or SKU'
+      fill_in 'add_description', with: 'Related Products Description'
       fill_in 'add_discount', with: '0.8'
       click_link 'Add'
     end
@@ -30,7 +31,7 @@ RSpec.feature 'Admin Product Relation', :js do
       expect(page).to have_field('relation_discount_amount', with: '0.8')
       expect(column_text(2)).to eq other_product.name
       expect(column_text(3)).to eq product_relation_type.name
-      expect(column_text(3)).to eq product_relation_type.name
+      expect(page).to have_field('relation_description', with: 'Related Products Description')
     end
   end
 
@@ -42,6 +43,7 @@ RSpec.feature 'Admin Product Relation', :js do
       select2_search variant_relation_type.name, from: 'Type'
       select2_search other_variant.sku, from: 'Name or SKU'
       fill_in 'add_discount', with: '0.8'
+      fill_in 'add_description', with: 'Related Variants Description'
       click_link 'Add'
     end
 
@@ -49,7 +51,7 @@ RSpec.feature 'Admin Product Relation', :js do
       expect(page).to have_field('relation_discount_amount', with: '0.8')
       expect(column_text(2)).to eq other_variant.name_for_relation
       expect(column_text(3)).to eq variant_relation_type.name
-      expect(column_text(3)).to eq variant_relation_type.name
+      expect(page).to have_field('relation_description', with: 'Related Variants Description')
     end
   end
 
@@ -60,7 +62,8 @@ RSpec.feature 'Admin Product Relation', :js do
         relatable: product,
         related_to: other_product,
         relation_type: product_relation_type,
-        discount_amount: 0.5
+        discount_amount: 0.5,
+        description: 'Related Description'
       )
     end
 
@@ -78,17 +81,29 @@ RSpec.feature 'Admin Product Relation', :js do
         expect(page).to have_field('relation_discount_amount', with: '0.5')
         expect(column_text(2)).to eq other_product.name
         expect(column_text(3)).to eq product_relation_type.name
+        expect(page).to have_field('relation_description', with: 'Related Description')
       end
     end
 
     scenario 'update discount' do
       within_row(1) do
         fill_in 'relation_discount_amount', with: '0.9'
-        click_on 'Update'
+        find('#update_discount_amount').click
       end
 
       within_row(1) do
         expect(page).to have_field('relation_discount_amount', with: '0.9')
+      end
+    end
+
+    scenario 'update description' do
+      within_row(1) do
+        fill_in 'relation_description', with: 'Related description updated'
+        find('#update_description').click
+      end
+
+      within_row(1) do
+        expect(page).to have_field('relation_description', with: 'Related description updated')
       end
     end
 

--- a/spec/features/spree/variant/product_relation_spec.rb
+++ b/spec/features/spree/variant/product_relation_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'Admin Variant Relation', :js do
     within('#add-line-item') do
       select2_search product_relation_type.name, from: 'Type'
       select2_search other_product.name, from: 'Name or SKU'
+      fill_in 'add_description', with: 'Related Products Description'
       fill_in 'add_discount', with: '0.8'
       click_link 'Add'
     end
@@ -29,6 +30,7 @@ RSpec.feature 'Admin Variant Relation', :js do
       expect(page).to have_field('relation_discount_amount', with: '0.8')
       expect(column_text(2)).to eq other_product.name
       expect(column_text(3)).to eq product_relation_type.name
+      expect(page).to have_field('relation_description', with: 'Related Products Description')
     end
   end
 
@@ -39,6 +41,7 @@ RSpec.feature 'Admin Variant Relation', :js do
     within('#add-line-item') do
       select2_search variant_relation_type.name, from: 'Type'
       select2_search other_variant.sku, from: 'Name or SKU'
+      fill_in 'add_description', with: 'Related Variants Description'
       fill_in 'add_discount', with: '0.8'
       click_link 'Add'
     end
@@ -47,6 +50,7 @@ RSpec.feature 'Admin Variant Relation', :js do
       expect(page).to have_field('relation_discount_amount', with: '0.8')
       expect(column_text(2)).to eq other_variant.name_for_relation
       expect(column_text(3)).to eq variant_relation_type.name
+      expect(page).to have_field('relation_description', with: 'Related Variants Description')
     end
   end
 
@@ -57,7 +61,8 @@ RSpec.feature 'Admin Variant Relation', :js do
         relatable: variant,
         related_to: other_product,
         relation_type: product_relation_type,
-        discount_amount: 0.5
+        discount_amount: 0.5,
+        description: 'Related Description'
       )
     end
 
@@ -74,17 +79,29 @@ RSpec.feature 'Admin Variant Relation', :js do
         expect(page).to have_field('relation_discount_amount', with: '0.5')
         expect(column_text(2)).to eq other_product.name
         expect(column_text(3)).to eq product_relation_type.name
+        expect(page).to have_field('relation_description', with: 'Related Description')
       end
     end
 
     scenario 'update discount' do
       within_row(1) do
         fill_in 'relation_discount_amount', with: '0.9'
-        click_on 'Update'
+        find('#update_discount_amount').click
       end
 
       within_row(1) do
         expect(page).to have_field('relation_discount_amount', with: '0.9')
+      end
+    end
+
+    scenario 'update description' do
+      within_row(1) do
+        fill_in 'relation_description', with: 'Related description updated'
+        find('#update_description').click
+      end
+
+      within_row(1) do
+        expect(page).to have_field('relation_description', with: 'Related description updated')
       end
     end
 

--- a/spec/models/spree/calculator/related_product_discount_spec.rb
+++ b/spec/models/spree/calculator/related_product_discount_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Spree::Calculator::RelatedProductDiscount, type: :model do
         related_product = create(:product)
         relation_type   = create(:product_relation_type)
 
-        create(:product_relation, relatable: product, related_to: related_product, relation_type: relation_type, discount_amount: 1.0)
+        create(:product_relation, relatable: product, related_to: related_product, relation_type: relation_type, discount_amount: 1.0, description: 'Related Description')
       end
 
       # TODO: figure out what this test is trying to accomplish


### PR DESCRIPTION
This PR adds a new `Description` field in `Related Products` & `Related Variants` creation.


**Related Products**
![May-14-2019 11-47-17](https://user-images.githubusercontent.com/19948291/57689004-fe6b3700-763e-11e9-9d69-185437a89132.gif)


**Related Variants**
![May-14-2019 11-50-47](https://user-images.githubusercontent.com/19948291/57689019-06c37200-763f-11e9-8db4-ff354f18768a.gif)
