### PR TITLE
Fix unsetted `@relation_types` in admin variant edit view

### DIFF
--- a/app/decorators/controllers/admin/variants_controller/load_relation_types.rb
+++ b/app/decorators/controllers/admin/variants_controller/load_relation_types.rb
@@ -5,7 +5,7 @@ module SolidusRelatedProducts
     module VariantsController
       module LoadRelationTypes
         def self.prepended(base)
-          base.before_action :load_relation_types, only: [:edit]
+          base.before_action :load_relation_types, only: %i[edit update]
         end
 
         private


### PR DESCRIPTION
Quick Info
---
| Issue | Migrations? |
| -- | -- |
|#27| :-1: |

What does this change?
----
This PR fixes unsetted `@relation_types` in admin edit view If a validation error is added.
