### PR TITLE
Fix master link in releted variants product view

### DIFF
--- a/app/helpers/related_products_helper.rb
+++ b/app/helpers/related_products_helper.rb
@@ -5,6 +5,8 @@ module RelatedProductsHelper
     if object.instance_of? Spree::Product
       admin_product_path(object)
     elsif object.instance_of? Spree::Variant
+      return edit_admin_product_path(object.product) if object.is_master?
+
       edit_admin_product_variant_path(object.product, object)
     end
   end


### PR DESCRIPTION
Quick Info
---

| Issue | Migrations? |
| -- | -- |
|N/A| :-1: |

What does this change?
----
For master variants, there isn't view dedicated to editing.
If the variant is related to a master variant, return to the product edit page.