### PR TITLE
Change the require_tree directive with multiple requires

### DIFF
--- a/app/assets/javascripts/spree/backend/solidus_related_products.js
+++ b/app/assets/javascripts/spree/backend/solidus_related_products.js
@@ -1,2 +1,3 @@
 //= require spree/backend
-//= require_tree .
+//= require spree/backend/create_relation
+//= require spree/backend/related_to_autocomplete


### PR DESCRIPTION
This PR changes how the assets are required by replacing the `require_tree .` in favor of more specific `require`s.

This allows to override single files from gem assets for `assets:precompile` because `require_tree` looks up files only in the directory of the current file and does not look across multiple load paths (e.g. `app/assets` or `vendor/assets`). So if the current file is `[gem]/app/assets/javascripts/gem_name/application.js`, `Sprockets#require_tree` will only look in `[gem]/app/assets/javascripts/gem_name/` for more files and will not use the other load paths like `[my_app]/app/assets/…`.