### PR TITLE
Add Bi-Directional feature to the relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,21 @@ $ bundle exec rails g solidus_related_products:install
 
 You can create four different RelationTypes:
 
-| Applies From | Applies To |
-| - | - |
-| Spree::Product | Spree::Product |
-| Spree::Product | Spree::Variant |
-| Spree::Variant | Spree::Product |
-| Spree::Variant | Spree::Variant |
+| Applies From | Applies To | Bi-Directional available |
+| - | - | - |
+| Spree::Product | Spree::Product | Yes |
+| Spree::Product | Spree::Variant | No  |
+| Spree::Variant | Spree::Product | No  |
+| Spree::Variant | Spree::Variant | Yes |
+
+**Bi-Directional**
+You can optionally set the bi-directional flag (if available) to automatically create the inverse relation,
+the flag can be set only on the type creation and can't be changed later, this is needed to avoid unpredictable behavior
+in the case that the flag is changed.
+Keep in mind that if you remove one side of the relation, also the other hand will be removed, the same way happens
+for the description.
+The discounts are disabled for Bi-Directional by setting the discount amount to be only zero, this is needed
+because it's not clear how this feature should behave in this case.
 
 The following examples use a `Spree::Product -> Spree::Product` relation type.
 

--- a/app/models/spree/relation.rb
+++ b/app/models/spree/relation.rb
@@ -8,6 +8,8 @@ class Spree::Relation < ApplicationRecord
   validates :relation_type, :relatable, :related_to, presence: true
 
   after_create :create_inverse, unless: :has_inverse?, if: :bidirectional?
+  after_destroy :destroy_inverses,
+    if: Proc.new { |relation| relation.bidirectional? && relation.has_inverse? }
 
   delegate :bidirectional?, to: :relation_type, allow_nil: true
 
@@ -27,5 +29,9 @@ class Spree::Relation < ApplicationRecord
 
   def create_inverse
     self.class.create!(inverse_options.merge(description: description))
+  end
+
+  def destroy_inverses
+    inverses.each(&:destroy!)
   end
 end

--- a/app/models/spree/relation.rb
+++ b/app/models/spree/relation.rb
@@ -7,6 +7,9 @@ class Spree::Relation < ApplicationRecord
 
   validates :relation_type, :relatable, :related_to, presence: true
 
+  validates :discount_amount, numericality: true
+  validates :discount_amount, numericality: { equal_to: 0 }, if: :bidirectional?
+
   after_create :create_inverse, unless: :has_inverse?, if: :bidirectional?
   after_save :update_inverse, if: :bidirectional?
   after_destroy :destroy_inverses,

--- a/app/models/spree/relation.rb
+++ b/app/models/spree/relation.rb
@@ -6,4 +6,26 @@ class Spree::Relation < ApplicationRecord
   belongs_to :related_to, polymorphic: true
 
   validates :relation_type, :relatable, :related_to, presence: true
+
+  after_create :create_inverse, unless: :has_inverse?, if: :bidirectional?
+
+  delegate :bidirectional?, to: :relation_type, allow_nil: true
+
+  def has_inverse?
+    self.class.exists?(inverse_options)
+  end
+
+  def inverses
+    self.class.where(inverse_options)
+  end
+
+  private
+
+  def inverse_options
+    { relation_type: relation_type, relatable: related_to, related_to: relatable }
+  end
+
+  def create_inverse
+    self.class.create!(inverse_options.merge(description: description))
+  end
 end

--- a/app/models/spree/relation_type.rb
+++ b/app/models/spree/relation_type.rb
@@ -5,4 +5,13 @@ class Spree::RelationType < ApplicationRecord
 
   validates :name, :applies_from, :applies_to, presence: true
   validates :name, uniqueness: { case_sensitive: false }
+  validate :allowed_bidirectional, if: :bidirectional?
+
+  attr_readonly :bidirectional
+
+  private
+
+  def allowed_bidirectional
+    errors.add(:bidirectional, :bidirectional_not_allowed) unless applies_from == applies_to
+  end
 end

--- a/app/views/spree/admin/products/_related_products_table.html.erb
+++ b/app/views/spree/admin/products/_related_products_table.html.erb
@@ -31,9 +31,11 @@
           <% end %>
         </td>
         <td>
-          <%= form_for relation, url: admin_product_relation_path(relation.relatable, relation) do |f| %>
-            <%= f.text_field :discount_amount, class: 'form-control text-center' %>
-            <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary', id: 'update_discount_amount'  %>
+          <% unless relation.bidirectional? %>
+            <%= form_for relation, url: admin_product_relation_path(relation.relatable, relation) do |f| %>
+              <%= f.text_field :discount_amount, class: 'form-control text-center' %>
+              <%= f.button I18n.t('spree.update'), type: 'submit', class: 'button btn-primary', id: 'update_discount_amount'  %>
+            <% end %>
           <% end %>
         </td>
         <td class="actions">

--- a/app/views/spree/admin/relation_types/_form.html.erb
+++ b/app/views/spree/admin/relation_types/_form.html.erb
@@ -20,5 +20,12 @@
       <%= f.text_area :description, rows: 4, class: 'form-control' %>
       <%= error_message_on :relation_type, :description %>
     </div>
+    <% if @relation_type.new_record? %>
+      <div data-hook="bidirectional" class="form-group">
+        <%= f.label :bidirectional, I18n.t('spree.bidirectional') %><br />
+        <%= f.check_box :bidirectional, class: 'form-control' %>
+        <%= error_message_on :bidirectional, :bidirectional %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/spree/admin/relation_types/index.html.erb
+++ b/app/views/spree/admin/relation_types/index.html.erb
@@ -14,7 +14,8 @@
       <col style="width: 15%" />
       <col style="width: 15%" />
       <col style="width: 15%" />
-      <col style="width: 40%" />
+      <col style="width: 35%" />
+      <col style="width: 5%" />
       <col style="width: 15%" />
     </colgroup>
     <thead>
@@ -23,6 +24,7 @@
         <th><%= I18n.t('spree.applies_from') %></th>
         <th><%= I18n.t('spree.applies_to') %></th>
         <th><%= I18n.t('spree.description') %></th>
+        <th><%= I18n.t('spree.bidirectional') %></th>
         <th class="actions" data-hook="admin_pages_index_header_actions"></th>
       </tr>
     </thead>
@@ -33,6 +35,7 @@
           <td><%= relation_type.applies_from %></td>
           <td><%= relation_type.applies_to %></td>
           <td><%= relation_type.description %></td>
+          <td><%= relation_type.bidirectional? ? t('spree.say_yes') : t('spree.say_no') %></td>
           <td class="actions" data-hook="admin_relation_types_index_row_actions">
             <%= link_to_edit relation_type, no_text: true %>
             <%= link_to_delete relation_type, no_text: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,12 @@ en:
       spree/relation_type:
         one: Relation Type
         other: Relation Types
+    errors:
+      models:
+        spree/relation_type:
+          attributes:
+            bidirectional:
+              bidirectional_not_allowed: is allowed only when applied to the same models
   spree:
     admin:
       tab:
@@ -20,3 +26,4 @@ en:
     add_related_product: Add Related Product
     name_or_sku_short: Name or SKU
     no_relation_types: You need to configure Relation Types before you can use this feature.
+    bidirectional: Bi-Directional

--- a/db/migrate/20200402134239_add_bidirectional_to_spree_relation_type.rb
+++ b/db/migrate/20200402134239_add_bidirectional_to_spree_relation_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBidirectionalToSpreeRelationType < SolidusSupport::Migration[5.2]
+  def change
+    add_column :spree_relation_types, :bidirectional, :boolean, default: false
+  end
+end

--- a/lib/solidus_related_products/factories.rb
+++ b/lib/solidus_related_products/factories.rb
@@ -26,6 +26,12 @@ FactoryBot.define do
       association :relation_type, factory: [:relation_type, :from_variant_to_variant]
     end
 
+    trait :bidirectional do
+      before :create do |relation|
+        relation.relation_type.update!(bidirectional: true)
+      end
+    end
+
     factory :product_relation, traits: [:from_product_to_product]
     factory :variant_relation, traits: [:from_product_to_variant]
   end

--- a/spec/features/spree/admin/relation_types_spec.rb
+++ b/spec/features/spree/admin/relation_types_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe 'Admin Relation Types', :js do
       expect(page).to have_current_path spree.admin_relation_types_path, ignore_query: true
     end
 
+    it 'shows bidirectional checkbox' do
+      click_link 'New Relation Type'
+
+      expect(page).to have_field 'Bi-Directional'
+    end
+
     it 'shows validation errors with blank :name' do
       click_link 'New Relation Type'
       expect(page).to have_current_path spree.new_admin_relation_type_path, ignore_query: true
@@ -82,6 +88,10 @@ RSpec.describe 'Admin Relation Types', :js do
       before do
         within_row(1) { click_icon :edit }
         expect(page).to have_current_path(spree.edit_admin_relation_type_path(1))
+      end
+
+      it 'does not show bidirectional checkbox' do
+        expect(page).to_not have_field 'Bi-Directional'
       end
 
       it 'can update an existing relation type' do

--- a/spec/models/spree/relation_spec.rb
+++ b/spec/models/spree/relation_spec.rb
@@ -5,11 +5,43 @@ RSpec.describe Spree::Relation, type: :model do
     it { is_expected.to belong_to(:relation_type) }
     it { is_expected.to belong_to(:relatable) }
     it { is_expected.to belong_to(:related_to) }
+    it { is_expected.to delegate_method(:bidirectional?).to(:relation_type).allow_nil }
   end
 
   context 'validation' do
     it { is_expected.to validate_presence_of(:relation_type) }
     it { is_expected.to validate_presence_of(:relatable) }
     it { is_expected.to validate_presence_of(:related_to) }
+  end
+
+  context 'callbacks' do
+    describe 'after create' do
+      let(:inverse_relation) {
+        described_class.find_by(
+          relation_type: subject.relation_type,
+          relatable: subject.related_to,
+          related_to: subject.relatable,
+          description: subject.description
+        )
+      }
+
+      context 'when relation type is not bi-directional' do
+        it 'does not add an inverse relation' do
+          expect { create(:product_relation) }.to change { Spree::Relation.count }.from(0).to(1)
+
+          expect(inverse_relation).to_not be_present
+        end
+      end
+
+      context 'when relation type is bi-directional' do
+        subject { create(:product_relation, :bidirectional, description: 'Lorem Ipsum') }
+
+        it 'adds an inverse relation' do
+          expect { subject }.to change { Spree::Relation.count }.from(0).to(2)
+
+          expect(inverse_relation).to be_present
+        end
+      end
+    end
   end
 end

--- a/spec/models/spree/relation_spec.rb
+++ b/spec/models/spree/relation_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe Spree::Relation, type: :model do
     it { is_expected.to validate_presence_of(:relation_type) }
     it { is_expected.to validate_presence_of(:relatable) }
     it { is_expected.to validate_presence_of(:related_to) }
+    it { is_expected.to validate_numericality_of(:discount_amount) }
+
+    context 'when bi-directional' do
+      subject { create(:relation, :from_product_to_product, :bidirectional) }
+
+      it { is_expected.to validate_numericality_of(:discount_amount).is_equal_to(0) }
+    end
   end
 
   context 'callbacks' do

--- a/spec/models/spree/relation_spec.rb
+++ b/spec/models/spree/relation_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe Spree::Relation, type: :model do
       end
     end
 
+    describe 'after save' do
+      let(:old_description) { 'old description' }
+      let(:new_description) { 'Lorem Ipsum' }
+
+      subject { create(:product_relation, :bidirectional, description: old_description) }
+
+      it 'changes the inverse relation description' do
+        expect(inverse_relation.description).to eq(old_description)
+
+        subject.update(description: new_description)
+
+        expect(inverse_relation.reload.description).to eq(new_description)
+      end
+    end
+
     describe 'after destroy' do
       subject { product_relation.destroy! }
 

--- a/spec/models/spree/relation_spec.rb
+++ b/spec/models/spree/relation_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe Spree::Relation, type: :model do
   end
 
   context 'callbacks' do
-    describe 'after create' do
-      let(:inverse_relation) {
-        described_class.find_by(
-          relation_type: subject.relation_type,
-          relatable: subject.related_to,
-          related_to: subject.relatable,
-          description: subject.description
-        )
-      }
+    let(:inverse_relation) {
+      described_class.find_by(
+        relation_type: subject.relation_type,
+        relatable: subject.related_to,
+        related_to: subject.relatable,
+        description: subject.description
+      )
+    }
 
+    describe 'after create' do
       context 'when relation type is not bi-directional' do
         it 'does not add an inverse relation' do
           expect { create(:product_relation) }.to change { Spree::Relation.count }.from(0).to(1)
@@ -40,6 +40,28 @@ RSpec.describe Spree::Relation, type: :model do
           expect { subject }.to change { Spree::Relation.count }.from(0).to(2)
 
           expect(inverse_relation).to be_present
+        end
+      end
+    end
+
+    describe 'after destroy' do
+      subject { product_relation.destroy! }
+
+      context 'when relation type is not bi-directional' do
+        let!(:product_relation) { create(:product_relation, description: 'Lorem Ipsum') }
+
+        it 'does not destroy the inverse relation' do
+          expect { subject }.to change { Spree::Relation.count }.from(1).to(0)
+        end
+      end
+
+      context 'when relation type is bi-directional' do
+        let!(:product_relation) { create(:product_relation, :bidirectional, description: 'Lorem Ipsum') }
+
+        it 'destroyes the inverse relation' do
+          expect { subject }.to change { Spree::Relation.count }.from(2).to(0)
+
+          expect(inverse_relation).to_not be_present
         end
       end
     end

--- a/spec/models/spree/relation_type_spec.rb
+++ b/spec/models/spree/relation_type_spec.rb
@@ -10,12 +10,28 @@ RSpec.describe Spree::RelationType, type: :model do
     it { is_expected.to validate_presence_of(:applies_from) }
     it { is_expected.to validate_presence_of(:applies_to) }
     it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+    it { is_expected.to have_readonly_attribute(:bidirectional) }
 
     it 'does not create duplicate names' do
       create(:product_relation_type, name: 'Gears')
       expect {
         create(:product_relation_type, name: 'gears')
       }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    describe 'bidirectional validation' do
+      context 'when applies_from and applies_to are equal' do
+        subject { build(:relation_type, :from_product_to_product) }
+
+        it { expect(subject).to allow_values(true, false, nil).for(:bidirectional) }
+      end
+
+      context 'when applies_from and applies_to are not equal' do
+        subject { build(:relation_type, :from_product_to_variant) }
+
+        it { expect(subject).to allow_values(false, nil).for(:bidirectional) }
+        it { expect(subject).to_not allow_value(true).for(:bidirectional) }
+      end
     end
   end
 end


### PR DESCRIPTION
This feature allows an admin user to create bidirectional relations. Notice that, for now, the bidirectional can be applied when `applies_from` and `applies_to` refer to the same model.
When a bidirectional relation is created, an inverse with the same `description` is added, in the same way, when one side of the relation is removed, also the other hand is destroyed.
The Bi-Directional aren't applied to the updates, so a change to the `description` or the `discount` won't affect the inverse relation.
