### PR TITLE
Fix related product select form field

### DIFF
--- a/app/assets/javascripts/spree/backend/related_to_autocomplete.js.coffee
+++ b/app/assets/javascripts/spree/backend/related_to_autocomplete.js.coffee
@@ -16,7 +16,7 @@ class RelatedToAutocomplete
     $(@relatedToSelector).css('display', 'block')
 
   initializeProductSelect: ->
-    $(@relatedToSelector).productAutocomplete();
+    $(@relatedToSelector).productAutocomplete({ multiple: false });
 
   initializeVariantSelect: ->
     $(@relatedToSelector).variantAutocomplete();


### PR DESCRIPTION
The field to select a product in the related form allowed to choose from multiple products, but this was incorrect. Just one product can be selected for a relation.