### PR TITLE
Add :no_conflict configuration option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *~
 .#*
 .DS_Store
+.bundle
 .idea
 .project
 .sass-cache

--- a/app/decorators/models/solidus_related_products/product/add_relation_methods.rb
+++ b/app/decorators/models/solidus_related_products/product/add_relation_methods.rb
@@ -72,6 +72,7 @@ module SolidusRelatedProducts
       # it up the inheritance chain.
       # rubocop:disable Style/MissingRespondToMissing
       def method_missing(method, *args)
+        return super if ::SolidusRelatedProducts.config[:no_conflict]
         # Fix for Ruby 1.9
         raise NoMethodError if method == :to_ary
 

--- a/app/decorators/models/solidus_related_products/variant/add_relation_methods.rb
+++ b/app/decorators/models/solidus_related_products/variant/add_relation_methods.rb
@@ -52,6 +52,7 @@ module SolidusRelatedProducts
       # it up the inheritance chain.
       # rubocop:disable Style/MissingRespondToMissing
       def method_missing(method, *args)
+        return super if ::SolidusRelatedProducts.config[:no_conflict]
         # Fix for Ruby 1.9
         raise NoMethodError if method == :to_ary
 

--- a/app/views/spree/admin/products/_related_products.html.erb
+++ b/app/views/spree/admin/products/_related_products.html.erb
@@ -1,3 +1,3 @@
 <%= content_tag :li, class: ('active' if current == "Related Products") do %>
-  <%= link_to I18n.t('spree.related_products'), related_admin_product_url(@product) %>
+  <%= link_to I18n.t('spree.related_products'), spree.related_admin_product_url(@product) %>
 <% end if can?(:admin, Spree::Product) %>

--- a/lib/solidus_related_products/configuration.rb
+++ b/lib/solidus_related_products/configuration.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 module SolidusRelatedProducts
-  class Configuration
+  class Configuration < Spree::Preferences::Configuration
     # Define here the settings for this extension, e.g.:
     #
     # attr_accessor :my_setting
+    preference :no_conflict, :boolean, default: false
   end
 
   class << self

--- a/lib/solidus_related_products/configuration.rb
+++ b/lib/solidus_related_products/configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spree/preferences/configuration'
+
 module SolidusRelatedProducts
   class Configuration < Spree::Preferences::Configuration
     # Define here the settings for this extension, e.g.:

--- a/solidus_related_products.gemspec
+++ b/solidus_related_products.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'solidus_dev_support', '~> 2.3'
   spec.add_development_dependency 'rspec-activemodel-mocks'
   spec.add_development_dependency 'shoulda-matchers'
+  spec.add_development_dependency 'webdrivers'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,9 @@ dummy_env = "#{__dir__}/dummy/config/environment.rb"
 system 'bin/rake extension:test_app' unless File.exist? dummy_env
 require dummy_env
 
+# Require webdrivers
+require 'webdrivers'
+
 # Requires factories and other useful helpers defined in spree_core.
 require 'solidus_dev_support/rspec/feature_helper'
 


### PR DESCRIPTION
This PR adds `Spree::RelatedProductsConfiguration` class to allow for host app to pass in a `:no_conflict` configuration option.

If the `:no_conflict` configuration is set to `true`, then the method_missing defined relations in the product and variant decorators are disabled. This is to appease developers that think it is dangerous to allow end-users to define metaprogrammatic behavior in their application.

By default, `:no_conflict` is set to false so as not to break any existing apps.