### PR TITLE
Ensure `@relation_types` is assigned before #update

### DIFF
--- a/lib/decorators/backend/controllers/solidus_related_products/admin/variants_controller/load_relation_types.rb
+++ b/lib/decorators/backend/controllers/solidus_related_products/admin/variants_controller/load_relation_types.rb
@@ -5,7 +5,7 @@ module SolidusRelatedProducts
     module VariantsController
       module LoadRelationTypes
         def self.prepended(base)
-          base.before_action :load_relation_types, only: [:edit]
+          base.before_action :load_relation_types, only: [:edit, :update]
         end
 
         private


### PR DESCRIPTION
When the admin variants controller cannot successfully complete an
`#update` action, it re-renders the user back on the `#edit` action
view.

This causes `@relation_types` to be nil and makes the Deface template
that tries to load product relations error out on a
`@relation_types.empty?` block.

We can avoid this by just making sure this before action is performed on
`#update`, too.