### PR TITLE
Force minimum version of `autoprefixer-rails`

### DIFF
--- a/solidus_related_products.gemspec
+++ b/solidus_related_products.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'deface', '~> 1.0'
 
   spec.add_development_dependency 'solidus_dev_support', '~> 2.3'
+  spec.add_development_dependency 'autoprefixer-rails', '~> 10.2.5'
   spec.add_development_dependency 'rspec-activemodel-mocks'
   spec.add_development_dependency 'shoulda-matchers'
 end


### PR DESCRIPTION
At lesser versions, the test suite encounters an error and cannot run:

    Failure/Error: Unable to find eval (eval at <anonymous> ((execjs) to
      read failed line

    ExecJS::ProgramError:
      TypeError: Cannot read property 'version' of undefined
      # eval (eval at <anonymous> ((execjs):1:213), <anonymous>:1:10)
      # (execjs):1:213
      # (execjs):19:14
      # ...

This seems related to the issue reported on Solidus: solidusio/solidus#4055. Adding `autoprefixer-rails` at the latest version side-steps the issue.
