### PR TITLE
Point gem in README to the github version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Add solidus_related_products to your Gemfile:
 gem 'solidus_related_products'
 ```
 
+To get the latest changes, we suggest using the Github version:
+```ruby
+gem 'solidus_related_products', github: 'solidusio-contrib/solidus_related_products'
+```
+
 Bundle your dependencies and run the installation generator:
 
 ```shell


### PR DESCRIPTION
Resolves solidusio-contrib/solidus_related_products#89

Adds the suggestion in the README to install the gem directly from the Github repo. 