### PR TITLE
Fix constant reference in initializer

### DIFF
--- a/lib/solidus_related_products/engine.rb
+++ b/lib/solidus_related_products/engine.rb
@@ -12,7 +12,7 @@ module SolidusRelatedProducts
     engine_name 'solidus_related_products'
 
     initializer 'spree.promo.register.promotion.calculators' do |app|
-      app.config.spree.calculators.promotion_actions_create_adjustments << Spree::Calculator::RelatedProductDiscount
+      app.config.spree.calculators.promotion_actions_create_adjustments << "Spree::Calculator::RelatedProductDiscount"
     end
 
     class << self


### PR DESCRIPTION
In Rails 7, you can't reference autoloaded constants in initializers (for good reason!) These get stored as strings and constantized anyway, so we can just pass in the string.
