### PR TITLE
Update to remove deprecation warning in 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,16 @@ else
   gem 'solidus_frontend', github: 'solidusio/solidus', branch: branch
 end
 
+# solidus_legacy_promotions was extracted from solidus_core in v4.4. Pull it from
+# the same monorepo so the engine's legacy-promotions registration path is loaded
+# and exercised by the engine spec.
+if branch == 'main' || branch >= 'v4.4'
+  gem 'solidus_legacy_promotions',
+      github: 'solidusio/solidus',
+      branch: branch,
+      glob: 'legacy_promotions/*.gemspec'
+end
+
 gem 'coffee-rails', '~> 5.0'
 
 rails_version = ENV.fetch('RAILS_VERSION', '7.2')

--- a/lib/solidus_related_products/engine.rb
+++ b/lib/solidus_related_products/engine.rb
@@ -12,7 +12,15 @@ module SolidusRelatedProducts
     engine_name 'solidus_related_products'
 
     initializer 'spree.promo.register.promotion.calculators' do |app|
-      app.config.spree.calculators.promotion_actions_create_adjustments << "Spree::Calculator::RelatedProductDiscount"
+      if defined?(SolidusLegacyPromotions::Config)
+        # Solidus 4+: legacy promotions extracted into solidus_legacy_promotions
+        SolidusLegacyPromotions::Config.calculators["Spree::Promotion::Actions::CreateAdjustment"] <<
+          "Spree::Calculator::RelatedProductDiscount"
+      elsif Spree.solidus_gem_version < Gem::Version.new("4.0")
+        # Solidus 2/3: legacy promotions still live in core
+        app.config.spree.calculators.promotion_actions_create_adjustments <<
+          "Spree::Calculator::RelatedProductDiscount"
+      end
     end
 
     class << self

--- a/spec/lib/solidus_related_products/engine_spec.rb
+++ b/spec/lib/solidus_related_products/engine_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe SolidusRelatedProducts::Engine do
+  describe 'promotion calculator registration' do
+    if defined?(SolidusLegacyPromotions::Config)
+      it 'registers RelatedProductDiscount with solidus_legacy_promotions' do
+        expect(
+          SolidusLegacyPromotions::Config.calculators['Spree::Promotion::Actions::CreateAdjustment']
+        ).to include('Spree::Calculator::RelatedProductDiscount')
+      end
+    elsif Spree.solidus_gem_version < Gem::Version.new('4.0')
+      it 'registers RelatedProductDiscount with core promotion calculators' do
+        expect(
+          Rails.application.config.spree.calculators.promotion_actions_create_adjustments
+        ).to include('Spree::Calculator::RelatedProductDiscount')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Due to a personal quest to remove deprecation warnings, I updated the engine for the legacy discount gem so my logs and CI clear up. 